### PR TITLE
(feature/back-end/#53) SearchContentView에서 장르를 탭하였을 때 뜨는 뷰

### DIFF
--- a/Plinic.xcodeproj/project.pbxproj
+++ b/Plinic.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		91BC78E228A691CC002C38CF /* UserMyPlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BC78E128A691CC002C38CF /* UserMyPlaylistView.swift */; };
 		91BC78E428A6920F002C38CF /* UserMyPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BC78E328A6920F002C38CF /* UserMyPostView.swift */; };
 		D0023CBF290662CB006057B3 /* Genre.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0023CBE290662CB006057B3 /* Genre.swift */; };
+		D0023CC12906C5BE006057B3 /* GenreAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0023CC02906C5BD006057B3 /* GenreAPI.swift */; };
+		D0023CC32906D01A006057B3 /* GenreSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0023CC22906D01A006057B3 /* GenreSearchView.swift */; };
 		D01AE77129011C6B00117432 /* PostHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01AE77029011C6B00117432 /* PostHeaderView.swift */; };
 		D01C63A328A6B2280037813F /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = D01C63A228A6B2280037813F /* .gitignore */; };
 		D01C63A728A6D0180037813F /* PostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01C63A628A6D0180037813F /* PostView.swift */; };
@@ -79,6 +81,8 @@
 		91BC78E128A691CC002C38CF /* UserMyPlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserMyPlaylistView.swift; sourceTree = "<group>"; };
 		91BC78E328A6920F002C38CF /* UserMyPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserMyPostView.swift; sourceTree = "<group>"; };
 		D0023CBE290662CB006057B3 /* Genre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Genre.swift; sourceTree = "<group>"; };
+		D0023CC02906C5BD006057B3 /* GenreAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreAPI.swift; sourceTree = "<group>"; };
+		D0023CC22906D01A006057B3 /* GenreSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenreSearchView.swift; sourceTree = "<group>"; };
 		D01AE77029011C6B00117432 /* PostHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHeaderView.swift; sourceTree = "<group>"; };
 		D01C63A228A6B2280037813F /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		D01C63A628A6D0180037813F /* PostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostView.swift; sourceTree = "<group>"; };
@@ -143,6 +147,7 @@
 		D0023CB92906628F006057B3 /* CommonAPI */ = {
 			isa = PBXGroup;
 			children = (
+				D0023CC02906C5BD006057B3 /* GenreAPI.swift */,
 				D0023CBC290662A9006057B3 /* DTO */,
 			);
 			path = CommonAPI;
@@ -249,6 +254,7 @@
 				9113807728CF13E0006CD66A /* UserResult.swift */,
 				9113807928CF13F6006CD66A /* UserTopResult.swift */,
 				914AF7B128D88E640016C38C /* SearchDetail.swift */,
+				D0023CC22906D01A006057B3 /* GenreSearchView.swift */,
 			);
 			path = SearchViews;
 			sourceTree = "<group>";
@@ -532,6 +538,7 @@
 				91BC78E428A6920F002C38CF /* UserMyPostView.swift in Sources */,
 				D0229E6328FE8DD800C5F38C /* BackgroundVideo.swift in Sources */,
 				D04E4A6228AF664700D04543 /* PostDetailInfoView.swift in Sources */,
+				D0023CC12906C5BE006057B3 /* GenreAPI.swift in Sources */,
 				91014F1A2895841F00C58E8B /* GenreTagView.swift in Sources */,
 				D01F104E290452CB001B61D0 /* PlaylistInfo.swift in Sources */,
 				E84A3E102903B294007FAA78 /* Author.swift in Sources */,
@@ -556,6 +563,7 @@
 				D08E273F2893A56A00013A12 /* PlinicApp.swift in Sources */,
 				D08E27552896CC3000013A12 /* WebView.swift in Sources */,
 				D0B5D67C28F3084C00D07944 /* MyAppDelegate.swift in Sources */,
+				D0023CC32906D01A006057B3 /* GenreSearchView.swift in Sources */,
 				91BC78E228A691CC002C38CF /* UserMyPlaylistView.swift in Sources */,
 				91014F1C2895920100C58E8B /* UserContentView.swift in Sources */,
 				E8689D992905550500D2A03F /* UserInfo.swift in Sources */,

--- a/Plinic/Application/MainTabBarView.swift
+++ b/Plinic/Application/MainTabBarView.swift
@@ -19,7 +19,7 @@ struct MainTabBarView: View {
             }
             
             NavigationView{
-                SearchContentView()
+                SearchContentView(genres: [""])
             }
             .tabItem {
                 Image(systemName: "magnifyingglass")

--- a/Plinic/Back-End/CommonAPI/DTO/Genre.swift
+++ b/Plinic/Back-End/CommonAPI/DTO/Genre.swift
@@ -7,16 +7,19 @@
 
 import Foundation
 
-struct Genre: Codable {
-    
-    let names: [String]
-    
-    enum CodingKeys: String, CodingKey {
-        case names = "genre_name"
-    }
-    
-    static func createMock() -> Genre {
-        return Genre(
-            names: ["acoustic","blues","classical","jazz","children","disney","hip-hop","rock","j-pop","k-pop","new-age","opera","pop","reggae","tango","techno","singer-songwriter","r-n-b","british","disco","new-release","movies","soundtracks","edm","sleep","soul","study","summer","road-trip","rainy-day","dance","holidays","party","work-out","sad","romance"])
-    }
-}
+typealias Genres = [String]
+
+//FIXME: - GenreAPI가 완성 되면 고쳐 쓸 부분 주석처리
+//struct Genre: Codable {
+//
+//    let names: [String]
+//
+//    enum CodingKeys: String, CodingKey {
+//        case names = "genre_name"
+//    }
+//
+//    static func createMock() -> Genre {
+//        return Genre(
+//            names: ["acoustic","blues","classical","jazz","children","disney","hip-hop","rock","j-pop","k-pop","new-age","opera","pop","reggae","tango","techno","singer-songwriter","r-n-b","british","disco","new-release","movies","soundtracks","edm","sleep","soul","study","summer","road-trip","rainy-day","dance","holidays","party","work-out","sad","romance"])
+//    }
+//}

--- a/Plinic/Back-End/CommonAPI/DTO/Genre.swift
+++ b/Plinic/Back-End/CommonAPI/DTO/Genre.swift
@@ -8,18 +8,3 @@
 import Foundation
 
 typealias Genres = [String]
-
-//FIXME: - GenreAPI가 완성 되면 고쳐 쓸 부분 주석처리
-//struct Genre: Codable {
-//
-//    let names: [String]
-//
-//    enum CodingKeys: String, CodingKey {
-//        case names = "genre_name"
-//    }
-//
-//    static func createMock() -> Genre {
-//        return Genre(
-//            names: ["acoustic","blues","classical","jazz","children","disney","hip-hop","rock","j-pop","k-pop","new-age","opera","pop","reggae","tango","techno","singer-songwriter","r-n-b","british","disco","new-release","movies","soundtracks","edm","sleep","soul","study","summer","road-trip","rainy-day","dance","holidays","party","work-out","sad","romance"])
-//    }
-//}

--- a/Plinic/Back-End/CommonAPI/GenreAPI.swift
+++ b/Plinic/Back-End/CommonAPI/GenreAPI.swift
@@ -1,0 +1,35 @@
+//
+//  GenreAPI.swift
+//  Plinic
+//
+//  Created by MacBook Air on 2022/10/24.
+//
+
+import Foundation
+
+final class GenreAPI: ObservableObject {
+    
+    private let genresPath: String = "/plinic/genres" // 기본 path
+    
+    private let networkService = NetworkService.init()
+    
+    
+    
+    // MARK: - 게시물 목록(GET)
+    func getPostList(_ completion: @escaping ((Result<Genres, Error>) -> Void)) {
+        
+        networkService.request(path: genresPath) { result in
+            switch result {
+            case .success(let data):
+                do {
+                    let genres = try JSONDecoder.init().decode(Genres.self, from: data)
+                    completion(.success(genres))
+                } catch let error {
+                    completion(.failure(error))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/Plinic/Back-End/CommonAPI/GenreAPI.swift
+++ b/Plinic/Back-End/CommonAPI/GenreAPI.swift
@@ -15,8 +15,8 @@ final class GenreAPI: ObservableObject {
     
     
     
-    // MARK: - 게시물 목록(GET)
-    func getPostList(_ completion: @escaping ((Result<Genres, Error>) -> Void)) {
+    // MARK: - 장르 목록(GET)
+    func getGenres(_ completion: @escaping ((Result<Genres, Error>) -> Void)) {
         
         networkService.request(path: genresPath) { result in
             switch result {

--- a/Plinic/Search/SearchViews/GenreSearchView.swift
+++ b/Plinic/Search/SearchViews/GenreSearchView.swift
@@ -1,0 +1,57 @@
+//
+//  GenreSearchView.swift
+//  Plinic
+//
+//  Created by MacBook Air on 2022/10/24.
+//
+
+import SwiftUI
+
+struct GenreSearchView: View {
+    
+    @StateObject var postAPI: PostAPI = PostAPI()
+    @State var postData : PostList = PostList.create()
+    @State var postList: [Post] = [Post.creatEmpty()]
+    let genreName: String
+    
+    var body: some View {
+        ScrollView{
+            LazyVStack{
+                ForEach(postList, id: \.self) { post in
+                    PostView(profilePic: post.author.profilePic ?? "profileDefault", nickname: post.author.nickname, thumbnailImgURL: post.plInfo.thumbnailImgURL ?? "defaultImg", content: post.content, title: post.title, id: post.id)
+                        .onAppear() {
+                            if let last = self.postList.last,
+                               last == post,
+                               post.id >= 0,
+                               postList.count < postData.count
+                            {
+                                postAPI.getPostList(nextURL: postData.next) { result in
+                                    switch result {
+                                    case .success(let success):
+                                        self.postData = success
+                                        self.postList.append(contentsOf: success.results)
+                                    case .failure(let failure):
+                                        _ = failure
+                                    }
+                                }
+                            }
+                        }
+                }
+            } //ForEach
+        }
+        .navigationTitle(genreName)
+        .navigationBarTitleDisplayMode(.inline)
+        .onLoad() {
+            postAPI.getPostList(nextURL: self.postData.next) { result in
+                switch result {
+                case .success(let success):
+                    self.postList = success.results
+                    self.postData = success
+                case .failure(let failure):
+                    _ = failure
+                }
+                
+            }
+        }
+    }
+}

--- a/Plinic/Search/searchContentView.swift
+++ b/Plinic/Search/searchContentView.swift
@@ -9,8 +9,9 @@ import SwiftUI
 
 struct SearchContentView: View {
     
-    @State var genre: Genre = Genre.createMock()
-    
+    @StateObject var genreAPI: GenreAPI = GenreAPI()
+    //    @State var genre: Genre = Genre.createMock()
+    @State var genres: [String]
     var columns = [GridItem(.fixed(180)), GridItem(.fixed(180))]
     
     @State private var searchText = ""
@@ -24,13 +25,21 @@ struct SearchContentView: View {
                     .frame(height: 50)
                 ScrollView {
                     LazyVGrid(columns: columns) {
-                        ForEach(genre.names, id: \.self) {name in
-                            NavigationLink(destination: postContentView()){
-                                GenreThumbnail(genreImg: "defaultImg", genreName: "\(name)")
+                        ForEach(genres, id: \.self) { genre in
+                            NavigationLink(destination: GenreSearchView(genreName: genre)){
+                                GenreThumbnail(genreImg: "defaultImg", genreName: genre)
                             } // NavigationLink
-                            .navigationBarTitleDisplayMode(.inline)
-                            //                            .navigationTitle("\(i)")
                         } //Foreach
+                        .onAppear(){
+                            genreAPI.getPostList() { result in
+                                switch result {
+                                case .success(let success):
+                                    self.genres = success
+                                case .failure(let failure):
+                                    _ = failure
+                                }
+                            }
+                        }
                     } // VStack
                 } // ScrollView
             } // VStack
@@ -44,6 +53,6 @@ struct SearchContentView: View {
 
 struct SearchContentView_Previews: PreviewProvider {
     static var previews: some View {
-        SearchContentView()
+        SearchContentView(genres: [""])
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/70786167/197549861-5a8799df-9a33-4e37-9683-331ddc29c052.png)
## 부가 설명
<!-- 필요 시 작성 -->
- 장르를 탭하였을 때 빨간색 네모박스 안에 있는 장르 이름 처럼 네비게이션제목이 장르의 이름이 되게끔 설정
- PostContentView에는 공지 헤더가 있어서 별도의 GenreSearchView를 생성
## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->

- [x] 변경 사항을 적용하고 테스트를 해봤나요?
- [x] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요?
