### PR TITLE
:recycle: (jaewon/feature/refactor) 검색 관련 뷰를 구현할 때 편하도록 리팩토링

### DIFF
--- a/Plinic.xcodeproj/project.pbxproj
+++ b/Plinic.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		9113807228C79836006CD66A /* SearchResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9113807128C79836006CD66A /* SearchResultView.swift */; };
 		9113807828CF13E0006CD66A /* UserResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9113807728CF13E0006CD66A /* UserResult.swift */; };
 		9113807A28CF13F6006CD66A /* UserTopResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9113807928CF13F6006CD66A /* UserTopResult.swift */; };
-		914AF7B228D88E640016C38C /* SearchDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914AF7B128D88E640016C38C /* SearchDetail.swift */; };
+		914AF7B228D88E640016C38C /* MoreUserResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914AF7B128D88E640016C38C /* MoreUserResultsView.swift */; };
 		91BC78E228A691CC002C38CF /* UserMyPlaylistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BC78E128A691CC002C38CF /* UserMyPlaylistView.swift */; };
 		91BC78E428A6920F002C38CF /* UserMyPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BC78E328A6920F002C38CF /* UserMyPostView.swift */; };
 		D0023CBF290662CB006057B3 /* Genre.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0023CBE290662CB006057B3 /* Genre.swift */; };
@@ -78,7 +78,7 @@
 		9113807128C79836006CD66A /* SearchResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultView.swift; sourceTree = "<group>"; };
 		9113807728CF13E0006CD66A /* UserResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResult.swift; sourceTree = "<group>"; };
 		9113807928CF13F6006CD66A /* UserTopResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTopResult.swift; sourceTree = "<group>"; };
-		914AF7B128D88E640016C38C /* SearchDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDetail.swift; sourceTree = "<group>"; };
+		914AF7B128D88E640016C38C /* MoreUserResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreUserResultsView.swift; sourceTree = "<group>"; };
 		91BC78E128A691CC002C38CF /* UserMyPlaylistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserMyPlaylistView.swift; sourceTree = "<group>"; };
 		91BC78E328A6920F002C38CF /* UserMyPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserMyPostView.swift; sourceTree = "<group>"; };
 		D0023CBE290662CB006057B3 /* Genre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Genre.swift; sourceTree = "<group>"; };
@@ -255,7 +255,7 @@
 				9113807128C79836006CD66A /* SearchResultView.swift */,
 				9113807728CF13E0006CD66A /* UserResult.swift */,
 				9113807928CF13F6006CD66A /* UserTopResult.swift */,
-				914AF7B128D88E640016C38C /* SearchDetail.swift */,
+				914AF7B128D88E640016C38C /* MoreUserResultsView.swift */,
 				D0023CC22906D01A006057B3 /* GenreSearchView.swift */,
 			);
 			path = SearchViews;
@@ -533,8 +533,8 @@
 				E84A3E0E2903B274007FAA78 /* Post.swift in Sources */,
 				D08E274F2893C63500013A12 /* ThumbnailView.swift in Sources */,
 				E84A3E0A2903AFDB007FAA78 /* RandomAPI.swift in Sources */,
-				914AF7B228D88E640016C38C /* SearchDetail.swift in Sources */,
 				D06539B728AFCDBF008B5199 /* PostCreateView.swift in Sources */,
+				914AF7B228D88E640016C38C /* MoreUserResultsView.swift in Sources */,
 				D0B5D68628F30E7300D07944 /* KakaoAuthVM.swift in Sources */,
 				D0E6E46A29046B0D00BA875A /* PostDetail.swift in Sources */,
 				D052589328BC8E0300EDF8C4 /* GenreThumbnail.swift in Sources */,

--- a/Plinic/Back-End/PostAPI/DTO/Post.swift
+++ b/Plinic/Back-End/PostAPI/DTO/Post.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
-struct Post: Hashable ,Codable {
+struct Post: Codable {
+    
+    var uuid: UUID = .init()
     
     var author: Author
     let id : Int
@@ -50,16 +52,4 @@ struct Post: Hashable ,Codable {
             plInfo: .createMock()
         )
     }
-    
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-        hasher.combine(likerCount)
-        hasher.combine(title)
-        hasher.combine(isLike)
-        hasher.combine(content)
-    }
-    
-    static func == (lhs: Post, rhs: Post) -> Bool {
-        return lhs.id == rhs.id
-    } // postID를 1:1 대응 시켜줌
 }

--- a/Plinic/Post/postContentView.swift
+++ b/Plinic/Post/postContentView.swift
@@ -26,11 +26,11 @@ struct postContentView: View {
                 
                 ScrollView{
                     LazyVStack{
-                        ForEach(postList, id: \.self) { post in
+                        ForEach(postList, id: \.uuid) { post in
                             PostView(profilePic: post.author.profilePic ?? "profileDefault", nickname: post.author.nickname, thumbnailImgURL: post.plInfo.thumbnailImgURL ?? "defaultImg", content: post.content, title: post.title, id: post.id)
                                 .onAppear() {
                                     if let last = self.postList.last,
-                                       last == post,
+                                       last.id == post.id,
                                        post.id >= 0,
                                        postList.count < postData.count
                                     {
@@ -70,8 +70,26 @@ struct postContentView: View {
 struct postContentView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            postContentView()
-            postContentView()
+            postContentView(
+                postData: .createMock(),
+                postList: [
+                    .createMock(),
+                    .createMock(),
+                    .createMock(),
+                    .createMock(),
+                    .createMock()
+                ]
+            )
+            postContentView(
+                postData: .createMock(),
+                postList: [
+                    .createMock(),
+                    .createMock(),
+                    .createMock(),
+                    .createMock(),
+                    .createMock()
+                ]
+            )
                 .previewDevice("iPhone 8")
         }
     }

--- a/Plinic/Search/SearchViews/GenreSearchView.swift
+++ b/Plinic/Search/SearchViews/GenreSearchView.swift
@@ -17,27 +17,34 @@ struct GenreSearchView: View {
     var body: some View {
         ScrollView{
             LazyVStack{
-                ForEach(postList, id: \.self) { post in
-                    PostView(profilePic: post.author.profilePic ?? "profileDefault", nickname: post.author.nickname, thumbnailImgURL: post.plInfo.thumbnailImgURL ?? "defaultImg", content: post.content, title: post.title, id: post.id)
-                        .onAppear() {
-                            if let last = self.postList.last,
-                               last == post,
-                               post.id >= 0,
-                               postList.count < postData.count
-                            {
-                                postAPI.getPostList(nextURL: postData.next) { result in
-                                    switch result {
-                                    case .success(let success):
-                                        self.postData = success
-                                        self.postList.append(contentsOf: success.results)
-                                    case .failure(let failure):
-                                        _ = failure
-                                    }
+                ForEach(postList, id: \.uuid) { post in
+                    PostView(
+                        profilePic: post.author.profilePic ?? "profileDefault",
+                        nickname: post.author.nickname,
+                        thumbnailImgURL: post.plInfo.thumbnailImgURL ?? "defaultImg",
+                        content: post.content,
+                        title: post.title,
+                        id: post.id
+                    )
+                    .onAppear() {
+                        if let last = self.postList.last,
+                           last.id == post.id,
+                           post.id >= 0,
+                           postList.count < postData.count
+                        {
+                            postAPI.getPostList(nextURL: postData.next) { result in
+                                switch result {
+                                case .success(let postList):
+                                    self.postData = postList
+                                    self.postList.append(contentsOf: postList.results)
+                                case .failure(let failure):
+                                    _ = failure
                                 }
                             }
                         }
-                }
-            } //ForEach
+                    } // PostView
+                } // ForEach
+            }
         }
         .navigationTitle(genreName)
         .navigationBarTitleDisplayMode(.inline)
@@ -58,6 +65,18 @@ struct GenreSearchView: View {
 
 struct GenreSearchView_Previews: PreviewProvider {
     static var previews: some View {
-        GenreSearchView(genreName: "sd")
+        GenreSearchView(
+            postData: .createMock(),
+            postList: [
+                .createMock(),
+                .createMock(),
+                .createMock(),
+                .createMock(),
+                .createMock(),
+                .createMock(),
+                .createMock()
+            ],
+            genreName: "acoustic"
+        )
     }
 }

--- a/Plinic/Search/SearchViews/MoreUserResultsView.swift
+++ b/Plinic/Search/SearchViews/MoreUserResultsView.swift
@@ -1,5 +1,5 @@
 //
-//  searchDetail.swift
+//  MoreUserResultsView.swift
 //  Plinic
 //
 //  Created by 유경덕 on 2022/09/19.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct userDetail: View {
+struct MoreUserResultsView: View {
     
     @State private var sort: Int = 0
     
@@ -87,6 +87,6 @@ struct userDetail: View {
 
 struct userDetail_Previews: PreviewProvider {
     static var previews: some View {
-        userDetail()
+        MoreUserResultsView()
     }
 }

--- a/Plinic/Search/SearchViews/SearchResultView.swift
+++ b/Plinic/Search/SearchViews/SearchResultView.swift
@@ -27,7 +27,7 @@ struct SearchResultView: View {
                             
                             Spacer()
                             
-                            NavigationLink(destination: userDetail()){
+                            NavigationLink(destination: MoreUserResultsView()) {
                                 Text("검색결과 더보기 ->")
                                     .fontWeight(.bold)
                                     .font(.system(size: 18))
@@ -124,6 +124,3 @@ struct SearchResultView_Previews: PreviewProvider {
         SearchResultView()
     }
 }
-   
-
-


### PR DESCRIPTION
## 부가 설명
<!-- 필요 시 작성 -->
- Post DTO : uuid 사용하도록 변경(foreach 에서 uuid 로 사용)
- <img width="347" alt="image" src="https://user-images.githubusercontent.com/81426024/197725399-7f5d4d40-febe-4c90-9efe-51d74839d75e.png">

  - createMock() 함수로 같은 객체를 여러개 생성해도 모두 uuid 가 다름
  - <img width="183" alt="스크린샷 2022-10-25 17 20 22" src="https://user-images.githubusercontent.com/81426024/197725312-39846bfc-f1fa-4bdd-93ac-1054da02045a.png">



- 그외 리팩토링 & 코드 가독성 향상


## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->

- [ ] 변경 사항을 적용하고 테스트를 해봤나요? -> 서버 통신이 안돼서 Canvas preview 에서만 테스트 완료
- [x] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요?
