### PR TITLE
:sparkles: (jaewon/feature/back-end) 검색 API 구현 #74 & 검색 결과화면에서 데이터 뿌려주기

### DIFF
--- a/Plinic.xcodeproj/project.pbxproj
+++ b/Plinic.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		E8689D992905550500D2A03F /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8689D982905550500D2A03F /* UserInfo.swift */; };
 		E86ECD56290472090039D8BF /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86ECD55290472090039D8BF /* View+.swift */; };
 		E86ECD58290472190039D8BF /* ViewDidLoadModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E86ECD57290472190039D8BF /* ViewDidLoadModifier.swift */; };
+		E876C088290914B700237FF9 /* SearchAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E876C087290914B700237FF9 /* SearchAPI.swift */; };
+		E876C08A2909159600237FF9 /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = E876C0892909159600237FF9 /* SearchResult.swift */; };
 		E8C4A37229069A3900425064 /* MainTabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C4A37129069A3900425064 /* MainTabBarView.swift */; };
 		E8C4A3772906FCF200425064 /* PlaylistAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C4A3762906FCF200425064 /* PlaylistAPI.swift */; };
 		E8C6C58C29082DEF00479BDA /* RandomThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C6C58B29082DEF00479BDA /* RandomThumbnail.swift */; };
@@ -135,6 +137,8 @@
 		E8689D982905550500D2A03F /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
 		E86ECD55290472090039D8BF /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		E86ECD57290472190039D8BF /* ViewDidLoadModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewDidLoadModifier.swift; sourceTree = "<group>"; };
+		E876C087290914B700237FF9 /* SearchAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAPI.swift; sourceTree = "<group>"; };
+		E876C0892909159600237FF9 /* SearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResult.swift; sourceTree = "<group>"; };
 		E8C4A37129069A3900425064 /* MainTabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarView.swift; sourceTree = "<group>"; };
 		E8C4A3762906FCF200425064 /* PlaylistAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistAPI.swift; sourceTree = "<group>"; };
 		E8C6C58B29082DEF00479BDA /* RandomThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomThumbnail.swift; sourceTree = "<group>"; };
@@ -195,6 +199,7 @@
 			children = (
 				E84A3E142903B88B007FAA78 /* Network */,
 				D0023CB92906628F006057B3 /* CommonAPI */,
+				E876C0852909149900237FF9 /* SearchAPI */,
 				D047BA52290571B5008CA3E4 /* NoticeAPI */,
 				E8689D94290554B600D2A03F /* UserAPI */,
 				E84A3E062903AF5D007FAA78 /* PlaylistAPI */,
@@ -451,6 +456,23 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		E876C0852909149900237FF9 /* SearchAPI */ = {
+			isa = PBXGroup;
+			children = (
+				E876C087290914B700237FF9 /* SearchAPI.swift */,
+				E876C086290914AE00237FF9 /* DTO */,
+			);
+			path = SearchAPI;
+			sourceTree = "<group>";
+		};
+		E876C086290914AE00237FF9 /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				E876C0892909159600237FF9 /* SearchResult.swift */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
 		E8C4A3752906C52700425064 /* Application */ = {
 			isa = PBXGroup;
 			children = (
@@ -575,7 +597,9 @@
 				D04F1B96290915E80020D80C /* UIImage+.swift in Sources */,
 				D04183E4289D26890045C907 /* UserProfileEditView.swift in Sources */,
 				D0F4D4CF28FD93F90085EB28 /* PlinicColors.swift in Sources */,
+				E876C08A2909159600237FF9 /* SearchResult.swift in Sources */,
 				D047BA5429057212008CA3E4 /* NoticeAPI.swift in Sources */,
+				E876C088290914B700237FF9 /* SearchAPI.swift in Sources */,
 				E86ECD56290472090039D8BF /* View+.swift in Sources */,
 				E84A3E122903B2AD007FAA78 /* Playlist.swift in Sources */,
 				E86ECD58290472190039D8BF /* ViewDidLoadModifier.swift in Sources */,

--- a/Plinic/Back-End/SearchAPI/DTO/SearchResult.swift
+++ b/Plinic/Back-End/SearchAPI/DTO/SearchResult.swift
@@ -1,0 +1,46 @@
+//
+//  SearchResult.swift
+//  Plinic
+//
+//  Created by Jaewon on 2022/10/26.
+//
+
+import Foundation
+
+struct SearchResult: Codable {
+    
+    var users: [UserInfo]
+    let posts: [Post]
+    
+    enum CodingKeys: String, CodingKey {
+        case users
+        case posts
+    }
+    
+    static func createEmpty() -> Self {
+        return .init(users: [.createEmpty()], posts: [.createEmpty()])
+    }
+    
+    static func createMock() -> Self {
+        return .init(
+            users: [
+                .createMock(),
+                .createMock(),
+                .createMock(),
+                .createMock(),
+                .createMock(),
+                .createMock(),
+                .createMock()
+            ],
+            posts: [
+                .createMock(),
+                .createMock(),
+                .createMock(),
+                .createMock(),
+                .createMock(),
+                .createMock(),
+                .createMock()
+            ]
+        )
+    }
+}

--- a/Plinic/Back-End/SearchAPI/SearchAPI.swift
+++ b/Plinic/Back-End/SearchAPI/SearchAPI.swift
@@ -1,0 +1,40 @@
+//
+//  SearchAPI.swift
+//  Plinic
+//
+//  Created by Jaewon on 2022/10/26.
+//
+
+import Foundation
+
+final class SearchAPI: ObservableObject {
+    
+    private let searchURL: String = ""
+    private let networkService = NetworkService.init()
+    
+    /// 검색 결과에 대한 응답을 가져오는 함수
+    func getSearchResult(
+        by searchWord: String,
+        _ completion: @escaping ((Result<SearchResult, Error>) -> Void)
+    ) {
+        
+        completion(.success(.createMock()))
+        
+        // MARK: API 미구현
+//        networkService.request(path: searchURL) { result in
+//            switch result {
+//            case .success(let data):
+//                do {
+//                    let recentNotice = try JSONDecoder.init().decode(RecentNotice.self, from: data)
+//                    completion(.success(recentNotice))
+//                } catch let error {
+//                    print(error)
+//                    completion(.failure(error))
+//                }
+//            case .failure(let error):
+//                print(error)
+//                completion(.failure(error))
+//            }
+//        }
+    }
+}

--- a/Plinic/Views/Search/SearchViews/MoreUserResultsView.swift
+++ b/Plinic/Views/Search/SearchViews/MoreUserResultsView.swift
@@ -11,10 +11,7 @@ struct MoreUserResultsView: View {
     
     @State private var sort: Int = 0
     
-    var users: [UserInfo] = [
-        .createMock(),
-        .createMock()
-    ]
+    @Binding var users: [UserInfo]
     
     var body: some View {
         List{
@@ -87,6 +84,12 @@ struct MoreUserResultsView: View {
 
 struct userDetail_Previews: PreviewProvider {
     static var previews: some View {
-        MoreUserResultsView()
+        MoreUserResultsView(users: .constant([
+            .createMock(),
+            .createMock(),
+            .createMock(),
+            .createMock(),
+            .createMock()
+        ]))
     }
 }

--- a/Plinic/Views/Search/SearchViews/SearchResultView.swift
+++ b/Plinic/Views/Search/SearchViews/SearchResultView.swift
@@ -9,10 +9,22 @@ import SwiftUI
 
 struct SearchResultView: View {
     
+    private let searchAPI: SearchAPI = .init()
+    
+    @Binding var searchText: String
+    @State private var searchResult: SearchResult = .createEmpty()
+    private var displayedUsers: [UserInfo] {
+        if searchResult.users.count >= 2 {
+            return .init(searchResult.users[searchResult.users.startIndex..<2])
+        } else {
+            return .init(searchResult.users[searchResult.users.startIndex..<searchResult.users.count])
+        }
+    }
+    
     let data = Array(1...3)
     
     var body: some View {
-        ZStack  {
+        ZStack {
             Color.black
                 .ignoresSafeArea()
             VStack() {
@@ -27,7 +39,7 @@ struct SearchResultView: View {
                             
                             Spacer()
                             
-                            NavigationLink(destination: MoreUserResultsView()) {
+                            NavigationLink(destination: MoreUserResultsView(users: $searchResult.users)) {
                                 Text("검색결과 더보기 ->")
                                     .fontWeight(.bold)
                                     .font(.system(size: 18))
@@ -39,25 +51,39 @@ struct SearchResultView: View {
                         }//HStack
                         
                         Rectangle()
-                                 .fill(Color.white)
-                                 .frame(minWidth: 200, maxHeight: 2)
-                                 .padding(.top, 10)
-                                 .padding(.leading, 10)
+                            .fill(Color.white)
+                            .frame(minWidth: 200, maxHeight: 2)
+                            .padding(.top, 10)
+                            .padding(.leading, 10)
                         Text("상위 검색결과")
                             .foregroundColor(Color.white)
                             .fontWeight(.bold)
                             .font(.system(size: 15))
                             .frame(minWidth: 300, maxHeight: 20, alignment: .leading)
                             .padding([.top, .leading], 10)
-                        NavigationLink(destination: UserContentView()) {
-                            HStack(alignment: .bottom){
-                                userTopResult(profileImg: "random1", nickName: "Hi", infoCount: 12)
-                                userResult(profileImg: "random1", nickName: "ddddd")
-                                    .padding(.leading, 10)
-                            }//HStack
-                            .padding()
-                            .padding(.top, 10)
-                        }
+                        
+                        
+                        HStack(alignment: .bottom) {
+                            ForEach(displayedUsers, id: \.uuid) { userInfo in
+                                
+                                userResult(
+                                    profileImg: userInfo.profileImageUrl,
+                                    nickName: userInfo.nickName
+                                )
+                                .padding(.leading, 10)
+
+//                                userTopResult(
+//                                    profileImg: "",
+//                                    nickName: "Hi",
+//                                    infoCount: 12
+//                                )
+                            }
+                        }//HStack
+                        .padding()
+                        .padding(.top, 10)
+                        
+                        
+                        
                     }//VStack
                     .padding(.leading, 10)
                 }//HStack
@@ -73,6 +99,7 @@ struct SearchResultView: View {
                             
                             Spacer()
                             
+                            // FIXME: 검색어와 관련된 post list 보여주도록 구현 필요
                             NavigationLink(destination: PostContentView()){
                                 Text("검색결과 더보기 ->")
                                     .fontWeight(.bold)
@@ -84,10 +111,10 @@ struct SearchResultView: View {
                             .padding(.trailing, 15)
                         }//HStack
                         Rectangle()
-                                 .fill(Color.white)
-                                 .frame(minWidth: 200, maxHeight: 2)
-                                 .padding(.top, 10)
-                                 .padding(.leading, 10)
+                            .fill(Color.white)
+                            .frame(minWidth: 200, maxHeight: 2)
+                            .padding(.top, 10)
+                            .padding(.leading, 10)
                         Text("상위 검색결과")
                             .foregroundColor(Color.white)
                             .fontWeight(.bold)
@@ -96,14 +123,21 @@ struct SearchResultView: View {
                             .padding([.top, .leading], 10)
                         ScrollView(.horizontal) {
                             HStack(spacing:15) {
-                                ForEach(data, id: \.self) {i in
-                                    VStack() {
-                                        ThumbnailView(imageUrl: "defaultImg")
-                                        Text("\(i)")
-                                            .foregroundColor(Color.white)
-                                            .fontWeight(.bold)
-                                            .font(.system(size: 15))
-                                    }//VStack
+                                ForEach(searchResult.posts, id: \.uuid) { post in
+                                    NavigationLink(
+                                        destination: {
+                                            PostDetailView(postId: post.id)
+                                        },
+                                        label: {
+                                            VStack() {
+                                                ThumbnailView(imageUrl: post.plInfo.thumbnailImgURL ?? "defaultImg")
+                                                Text("\(post.title)")
+                                                    .foregroundColor(Color.white)
+                                                    .fontWeight(.bold)
+                                                    .font(.system(size: 15))
+                                            }//VStack
+                                        }
+                                    )
                                 } //ForEach
                             }//HSTack
                         }
@@ -116,11 +150,21 @@ struct SearchResultView: View {
                 .padding(.top, 15)
             }//VStack
         }//ZStack
+        .onLoad() {
+            searchAPI.getSearchResult(by: searchText) { result in
+                switch result {
+                case .success(let searchResult):
+                    self.searchResult = searchResult
+                case .failure(let error):
+                    _ = error
+                }
+            }
+        }
     }
 }
 
 struct SearchResultView_Previews: PreviewProvider {
     static var previews: some View {
-        SearchResultView()
+        SearchResultView(searchText: .constant("재즈"))
     }
 }

--- a/Plinic/Views/Search/SearchViews/searchBar.swift
+++ b/Plinic/Views/Search/SearchViews/searchBar.swift
@@ -17,7 +17,7 @@ struct SearchBar: View {
             NavigationLink(
                 isActive: $isActive,
                 destination: {
-                    SearchResultView()
+                    SearchResultView(searchText: $searchText)
                 },
                 label: {}
             )


### PR DESCRIPTION
## 부가 설명
<!-- 필요 시 작성 -->
- 검색 시 검색어에 맞는 데이터를 가져옴 (현재 mock data 연결)
  - <img width="293" alt="image" src="https://user-images.githubusercontent.com/81426024/197986804-abcc29e1-da2e-4b2a-982d-0afe90d516ae.png">
- 검색 결과 화면에서 게시글 상세 안들어가 지는 문제 수정
- 유저 검색 결과 터치 액션 삭제
- https://github.com/ILGOB/Plinic-iOS/issues/74

## PR Checklist
<!-- 만족하는 항목은 [ ] 안에 "x" 를 입력해주세요. (ex: [x]) -->

- [x] 변경 사항을 적용하고 테스트를 해봤나요?
- [x] [Code Convention](https://il-gob.notion.site/Code-Convention-29ce0d4e48e440b9bc74b1a19c99b57b)을 준수했나요?
